### PR TITLE
fix(ship): address CodeRabbitAI review findings for ship system

### DIFF
--- a/ageofficial/index.html
+++ b/ageofficial/index.html
@@ -9,6 +9,5 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
-    <!-- <style src="vue-multiselect/dist/vue-multiselect.css"></style> -->
   </body>
 </html>

--- a/ageofficial/package-lock.json
+++ b/ageofficial/package-lock.json
@@ -17,6 +17,7 @@
         "@roll20-official/beacon-sdk": "^0.0.31",
         "@vueup/vue-quill": "^1.0.0-alpha.40",
         "bootstrap": "^5.3.3",
+        "dompurify": "^3.4.1",
         "handlebars": "^4.7.7",
         "jsonpath": "^1.1.1",
         "lodash": "^4.17.21",
@@ -34,6 +35,7 @@
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.2.0",
         "@testing-library/vue": "^7.0.0",
+        "@types/dompurify": "^3.2.0",
         "@types/jsdom": "^21.1.0",
         "@types/jsonpath": "^0.2.4",
         "@types/lodash": "^4.14.202",
@@ -1486,6 +1488,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "dompurify": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1710,6 +1722,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -4464,6 +4482,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/ageofficial/package.json
+++ b/ageofficial/package.json
@@ -31,6 +31,7 @@
     "@roll20-official/beacon-sdk": "^0.0.31",
     "@vueup/vue-quill": "^1.0.0-alpha.40",
     "bootstrap": "^5.3.3",
+    "dompurify": "^3.4.1",
     "handlebars": "^4.7.7",
     "jsonpath": "^1.1.1",
     "lodash": "^4.17.21",
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.2.0",
     "@testing-library/vue": "^7.0.0",
+    "@types/dompurify": "^3.2.0",
     "@types/jsdom": "^21.1.0",
     "@types/jsonpath": "^0.2.4",
     "@types/lodash": "^4.14.202",

--- a/ageofficial/src/App.vue
+++ b/ageofficial/src/App.vue
@@ -60,9 +60,6 @@
             </div>
             <div class="age-header-menu">
               <div class="dropdown" style="text-align: right;">
-                <!-- <button class="btn" type="button" aria-expanded="false">
-                  <font-awesome-icon style="font-size: 24px;" :icon="['fa', 'bars']" />
-                </button> -->
                 <ul class="dropdown-menu">
                   <li>
                     <button v-if="settings.whisperRollsGM === 'toggle'" :class="{ active: settings.whisperRollsGMToggle }" class="age-btn" @click="settings.whisperRollsGMToggle = !settings.whisperRollsGMToggle">

--- a/ageofficial/src/components/ship/ShipAccordionEntryView.vue
+++ b/ageofficial/src/components/ship/ShipAccordionEntryView.vue
@@ -10,8 +10,8 @@
             <div class="age-ship-weapon-range">{{ weapon.range }}</div>
             <div style="display:grid;align-items:center;height:100%;">
                 <button type="button" class="config-btn age-icon-btn" @click="onRollDamage"
-                    :disabled="!weapon.damage"
-                    v-tippy="{ content: weapon.damage ? 'Roll ' + weapon.name + ' damage (' + weapon.damage + ')' : 'No damage formula set' }">
+                    :disabled="!weapon.damage || weapon.offline || props.systemOffline"
+                    v-tippy="{ content: props.systemOffline ? 'System Offline' : weapon.offline ? 'Weapon Offline' : weapon.damage ? 'Roll ' + weapon.name + ' damage (' + weapon.damage + ')' : 'No damage formula set' }">
                     <font-awesome-icon :icon="['fa', 'dice']" />
                 </button>
             </div>
@@ -68,7 +68,7 @@ defineEmits(['edit']);
 
 async function onRollDamage() {
     const w = props.weapon;
-    if (!w.damage) return;
+    if (!w.damage || w.offline || props.systemOffline) return;
     const match = w.damage.match(/^(\d+)d(\d+)$/i);
     if (!match) return;
     const count = parseInt(match[1]);

--- a/ageofficial/src/components/ship/ShipCrewSection.vue
+++ b/ageofficial/src/components/ship/ShipCrewSection.vue
@@ -89,7 +89,7 @@
                     class="accordion-collapse age-accordion-collapse collapsed collapse">
                     <div class="accordion-body">
                         <div class="age-quality-accordion">
-                            <span v-html="stunt.description || '—'"></span>
+                            <span v-html="DOMPurify.sanitize(stunt.description || '—')"></span>
                         </div>
                     </div>
                 </div>
@@ -228,6 +228,7 @@
 import { useShipStore } from '@/sheet/stores/character/shipStore';
 import { ref, computed } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
+import DOMPurify from 'dompurify';
 import ShipModelVue from './ShipModelVue.vue';
 import VueMultiselect from 'vue-multiselect';
 import { QuillEditor } from '@vueup/vue-quill';
@@ -283,11 +284,11 @@ const openModal = (mode, option) => {
 };
 
 const openCrewEdit = (member) => {
-    crewMember.value = { ...member, ability: [...(member.ability || [])] };
+    crewMember.value = { ...member, ability: (member.ability || []).map(a => structuredClone(a)) };
     selectedModalOption.value = 'crew';
     modalMode.value = 'edit';
     crewMemberRoles.value = (member.ability || [])
-        .map(a => shipCrewRoles.find(r => r.ability === a.ability))
+        .map(a => shipCrewRoles.find(r => String(r._id) === String(a._id)))
         .filter(Boolean);
     showModal.value = true;
 };
@@ -318,7 +319,7 @@ const closeModal = () => {
 
 const updateSelected = (value) => {
     crewMember.value.ability = value.map(v => {
-        const existing = crewMember.value.ability.find(a => a.ability === v.ability);
+        const existing = crewMember.value.ability.find(a => String(a._id) === String(v._id));
         return existing ?? {
             _id: String(v._id),
             ability: v.ability,

--- a/ageofficial/src/components/ship/ShipQFSection.vue
+++ b/ageofficial/src/components/ship/ShipQFSection.vue
@@ -48,7 +48,7 @@
                 data-bs-parent="#age-qf-accordion">
                 <div class="accordion-body">
                     <div class="age-quality-accordion">
-                        <span v-html="qf.description || '—'"></span>
+                        <span v-html="DOMPurify.sanitize(qf.description || '—')"></span>
                     </div>
                 </div>
             </div>
@@ -104,6 +104,7 @@
 <script setup>
 import { ref } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
+import DOMPurify from 'dompurify';
 import ShipModelVue from './ShipModelVue.vue';
 import { useShipStore } from '@/sheet/stores/character/shipStore';
 import { QuillEditor } from '@vueup/vue-quill';

--- a/ageofficial/src/components/ship/ShipStuntsView.vue
+++ b/ageofficial/src/components/ship/ShipStuntsView.vue
@@ -139,7 +139,7 @@ const ROLES = [
     { key: 'pilot',     name: 'Pilot'     },
     { key: 'engineer',  name: 'Engineer'  },
     { key: 'gunner',    name: 'Gunner'    },
-    { key: 'sensor',    name: 'Sensor'    },
+    { key: 'sensors',   name: 'Sensors'   },
 ];
 
 const emptyStunt = (role = 'commander') => ({ _id: '', role, sp: 1, name: '', description: '' });

--- a/ageofficial/src/sheet/stores/character/shipStore.ts
+++ b/ageofficial/src/sheet/stores/character/shipStore.ts
@@ -40,7 +40,7 @@ export type ShipHydrate = {
     weapons?: Record<string, ShipWeapon>;
     crew?: Record<string, CrewHydrate>;
     qualityFlaws?: Record<string, QualityFlawHydrate>;
-    shipStunts?: { commander: number; pilot: number; engineer: number; gunner: number; sensor: number; };
+    shipStunts?: { commander: number; pilot: number; engineer: number; gunner: number; sensors: number; };
     stuntDefs?: Record<string, ShipStuntDef>;
     losses?: ShipLosses;
     seriousLosses?: ShipSeriousLosses;
@@ -71,7 +71,7 @@ export type QualityFlawHydrate = {
 
 export type ShipStuntDef = {
     _id: string;
-    role: 'commander' | 'pilot' | 'engineer' | 'gunner' | 'sensor';
+    role: 'commander' | 'pilot' | 'engineer' | 'gunner' | 'sensors';
     sp: number;
     name: string;
     description: string;
@@ -97,7 +97,7 @@ export const useShipStore = defineStore('ship', () => {
     const qualityFlaws = ref<QualityFlawHydrate[]>([]);
     const stuntDefs = ref<ShipStuntDef[]>([]);
     const weapons = ref<ShipWeapon[]>([]);
-    const shipStunts = ref<{ commander: number; pilot: number; engineer: number; gunner: number; sensor: number; }>({ commander: 0, pilot: 0, engineer: 0, gunner: 0, sensor: 0 });
+    const shipStunts = ref<{ commander: number; pilot: number; engineer: number; gunner: number; sensors: number; }>({ commander: 0, pilot: 0, engineer: 0, gunner: 0, sensors: 0 });
     const pdcFiredThisRound = ref<boolean>(false);
 
     const losses = ref<ShipLosses>({
@@ -230,7 +230,6 @@ export const useShipStore = defineStore('ship', () => {
                 { label: 'Sensors (Current)', value: sensorsCurrent.value },
             ],
         });
-        pdcFiredThisRound.value = true;
     };
 
     // Damage Control: 3d6 + Intelligence (Engineering focus) vs TN 11
@@ -384,7 +383,7 @@ export const useShipStore = defineStore('ship', () => {
         weapons.value = weapons.value.filter((m) => m._id !== memberId);
     };
 
-    const resetShipStunts = (stuntType: 'commander' | 'pilot' | 'engineer' | 'gunner' | 'sensor') => {
+    const resetShipStunts = (stuntType: 'commander' | 'pilot' | 'engineer' | 'gunner' | 'sensors') => {
         shipStunts.value[stuntType] = 0;
     };
 
@@ -402,9 +401,7 @@ export const useShipStore = defineStore('ship', () => {
                 _id,
                 name,
                 primaryRole,
-                ability: arrayToObject(
-                    (ability || []).map((a: any) => ({ ...a, _id: String(a._id ?? uuidv4()) }))
-                ),
+                ability: arrayToObject(ability || []),
             }))),
             qualityFlaws: arrayToObject(qualityFlaws.value),
             stuntDefs: arrayToObject(stuntDefs.value),
@@ -438,7 +435,7 @@ export const useShipStore = defineStore('ship', () => {
         qualityFlaws.value = objectToArray(hydrateStore.qualityFlaws || {}) || [];
         stuntDefs.value = objectToArray(hydrateStore.stuntDefs || {}) || [];
         weapons.value = objectToArray(hydrateStore.weapons || {}) || [];
-        shipStunts.value = hydrateStore.shipStunts || { commander: 0, pilot: 0, engineer: 0, gunner: 0, sensor: 0 };
+        shipStunts.value = hydrateStore.shipStunts || { commander: 0, pilot: 0, engineer: 0, gunner: 0, sensors: 0 };
         losses.value = hydrateStore.losses ?? { collateral: 0, hull: 0, maneuverability: 0, sensors: 0, weaponsSystem: 0 };
         seriousLosses.value = hydrateStore.seriousLosses ?? { reactorOffline: false, railgunsOffline: false, torpedoesOffline: false, pdcsOffline: false };
         pdcFiredThisRound.value = hydrateStore.pdcFiredThisRound ?? false;

--- a/ageofficial/src/views/ShipView.vue
+++ b/ageofficial/src/views/ShipView.vue
@@ -49,20 +49,6 @@
                 <!-- Combat Actions Card -->
                 <div class="section-card" style="margin-bottom: 15px;">
                     <h4>Actions</h4>
-
-                    <!-- Enemy Sensors + High-G inputs (hidden until roll system is wired) -->
-                    <!-- <div class="age-ship-combat-context">
-                        <div class="age-ship-context-row">
-                            <label class="age-input-label">Enemy Sensors</label>
-                            <input type="number" class="age-input age-num-input" v-model.number="enemySensorsInput" min="0" />
-                        </div>
-                        <div class="age-ship-context-row" v-if="highGAllowed">
-                            <label class="age-input-label">High-G Bonus (1–6)</label>
-                            <input type="number" class="age-input age-num-input" v-model.number="highGBonusInput" min="0" max="6" />
-                        </div>
-                        <div v-if="!highGAllowed" class="age-ship-warning">Reactor Offline — High-G unavailable</div>
-                    </div> -->
-
                     <!-- Action Buttons -->
                     <div class="age-ship-actions">
                         <button class="age-btn" @click="onElectronicWarfare">


### PR DESCRIPTION
- Sanitize v-html with DOMPurify in ShipCrewSection and ShipQFSection (ship-specific fix; project-wide v-html pattern left unchanged)
- Fix crew role lookup collision in openCrewEdit and updateSelected: Engineer and Sensors both map to Intelligence, causing the wrong role to be selected on edit; lookup now uses the unique _id field instead of the shared ability string
- Remove pdcFiredThisRound mutation from rollPointDefense — defensive point-defense rolls should not mark offensive PDCs as spent; the flag is now only set by the user via the UI toggle
- Remove uuidv4() generation from dehydrate() crew ability mapping — ability _id values are stable at creation time (role IDs 1–5) so serialization should not mint new keys on every save
- Normalize 'sensor' → 'sensors' throughout shipStore types, defaults, and hydrate/dehydrate paths to match the rest of the ship system