### PR TITLE
feat(fage2e): add TechnoFantasy weapon groups (Blaster Pistols, Blast…

### DIFF
--- a/ageofficial/src/components/attack/AttackModal.vue
+++ b/ageofficial/src/components/attack/AttackModal.vue
@@ -151,8 +151,8 @@
   </Transition>
 </template>
 <script setup>
-import { ref } from 'vue';
-import { expanseWG, fage2eWG, mageWG } from './weaponGroups';
+import { ref, computed } from 'vue';
+import { expanseWG, fage2eWG, mageWG, technofantasyWG } from './weaponGroups';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore'
 import { at } from 'lodash';
 
@@ -161,18 +161,18 @@ const props = defineProps({
   attack: { type: Object },
 })
 const settings = useSettingsStore();
-const weaponGroups = ref(fage2eWG);
-switch(settings.gameSystem){
-  case 'mage':
-    weaponGroups.value = mageWG;
-  break;
-  case 'expanse':
-      weaponGroups.value = expanseWG;
-    break;
-  default:
-    weaponGroups.value = fage2eWG;
-  break;
-};
+const weaponGroups = computed(() => {
+  let base;
+  switch (settings.gameSystem) {
+    case 'mage':    base = mageWG;    break;
+    case 'expanse': base = expanseWG; break;
+    default:        base = fage2eWG;  break;
+  }
+  if (settings.technofantasy) {
+    return [...new Set([...base, ...technofantasyWG])].sort();
+  }
+  return base;
+});
 const setWeaponGroupAbility = () => {
     switch(props.item.weaponGroup){
       // ACCURACY

--- a/ageofficial/src/components/attack/WeaponGroupsModal.vue
+++ b/ageofficial/src/components/attack/WeaponGroupsModal.vue
@@ -21,43 +21,40 @@
         </div>
     </Transition>
 </template>
-<script setup>
+<script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useCharacterStore } from '@/sheet/stores/character/characterStore';
-import {blueRoseWG, cthulhuWG, fage1eWG, fage2eWG, mageWG } from '@/components/attack/weaponGroups';
+import { blueRoseWG, cthulhuWG, fage1eWG, fage2eWG, mageWG, technofantasyWG } from '@/components/attack/weaponGroups';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 
 const props = defineProps({
-  show:Boolean,
+  show: Boolean,
 })
+const settings = useSettingsStore();
 const char = useCharacterStore();
-const weaponGroups = ref(fage2eWG);
 const wgs = ref(char.weaponGroups ? JSON.parse(char.weaponGroups) : [])
 
-function handleCheckboxChange(wg) {  
-  if(wgs.value.includes(wg)){
-    wgs.value = wgs.value.filter(item => item !== wg);
+const weaponGroups = computed(() => {
+  let base: string[];
+  switch (settings.gameSystem) {
+    case 'mage':   base = mageWG;     break;
+    case 'fage1e': base = fage1eWG;   break;
+    case 'bluerose': base = blueRoseWG; break;
+    case 'cthulhu': base = cthulhuWG; break;
+    default:       base = fage2eWG;   break;
+  }
+  if (settings.technofantasy) {
+    return [...new Set([...base, ...technofantasyWG])].sort();
+  }
+  return base;
+});
+
+function handleCheckboxChange(wg: string) {
+  if (wgs.value.includes(wg)) {
+    wgs.value = wgs.value.filter((item: string) => item !== wg);
   } else {
     wgs.value.push(wg)
   }
   char.weaponGroups = JSON.stringify(wgs.value);
-}
-
-switch(useSettingsStore().gameSystem){
-  case 'fage2e':
-    weaponGroups.value = fage2eWG;
-  break;
-  case 'mage':
-    weaponGroups.value = mageWG;
-  break;
-  case 'fage1e':
-    weaponGroups.value = fage1eWG;
-  break;
-  case 'bluerose':
-    weaponGroups.value = blueRoseWG;
-  break;
-  case 'cthulhu':
-    weaponGroups.value = cthulhuWG;
-  break;
 }
 </script>

--- a/ageofficial/src/components/attack/weaponGroups.ts
+++ b/ageofficial/src/components/attack/weaponGroups.ts
@@ -87,3 +87,8 @@ export const expanseWG = [
     'Rifles',
     'Throwing',
 ]
+
+export const technofantasyWG = [
+    'Blaster Longarms',
+    'Blaster Pistols',
+]

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -296,7 +296,7 @@
 <script setup>
   import { useInventoryStore } from '@/sheet/stores/inventory/inventoryStore';
   import { computed, ref } from 'vue';
-  import { fage2eWG,mageWG, blueRoseWG, expanseWG } from '../attack/weaponGroups';
+  import { fage2eWG, mageWG, blueRoseWG, expanseWG, technofantasyWG } from '../attack/weaponGroups';
   import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 
   const props = defineProps({
@@ -306,21 +306,19 @@
   })
 
   const settings = useSettingsStore();
-  const weaponGroups = ref(fage2eWG)
-  switch(settings.gameSystem){
-    case 'mage':
-      weaponGroups.value = mageWG;
-    break;
-    case 'blue rose':
-      weaponGroups.value = blueRoseWG;  
-    break;
-    case 'expanse':
-      weaponGroups.value = expanseWG;
-    break;
-    default:
-      weaponGroups.value = fage2eWG;
-    break;
-  }
+  const weaponGroups = computed(() => {
+    let base;
+    switch (settings.gameSystem) {
+      case 'mage':       base = mageWG;     break;
+      case 'blue rose':  base = blueRoseWG; break;
+      case 'expanse':    base = expanseWG;  break;
+      default:           base = fage2eWG;   break;
+    }
+    if (settings.technofantasy) {
+      return [...new Set([...base, ...technofantasyWG])].sort();
+    }
+    return base;
+  });
 
   const isArmor = computed(() => {
   return props.item.type === 'armor';

--- a/ageofficial/src/views/SettingsView.vue
+++ b/ageofficial/src/views/SettingsView.vue
@@ -46,7 +46,7 @@
             </div>       
           </div>
           <!-- // TODO Items unique to genre slices. Technofantasy, Cthulhu Awakens, Cyberpunk, etc. -->
-          <!-- <div class="row age-modal-row"  v-if="settings.gameSystem === 'fage1e' || settings.gameSystem === 'fage2e' || settings.gameSystem === 'cthulhu' || settings.gameSystem === 'mage'">
+          <div class="row age-modal-row"  v-if="settings.gameSystem === 'fage1e' || settings.gameSystem === 'fage2e' || settings.gameSystem === 'cthulhu' || settings.gameSystem === 'mage'">
             <h4>Genre Slices</h4>
             <div style="display: grid;grid-template-columns: repeat(2,1fr);">
               <div class=" input-group" v-if="settings.gameSystem === 'mage'">
@@ -54,24 +54,24 @@
                     <input type="checkbox"  v-model="settings.cyberpunk" @change="updateGameSystem" />
                     <span class="slider round" ></span>
                 </label>
-                <span class="age-toggle-label">Use Cyberpunk</span>
+                <span class="age-toggle-label">Cyberpunk</span>
               </div>
               <div class=" input-group" v-if="settings.gameSystem === 'fage1e' || settings.gameSystem === 'fage2e' || settings.gameSystem === 'cthulhu'">
               <label class="age-checkbox-toggle" style="margin:1rem;">
                   <input type="checkbox"  v-model="settings.cthulhuMythos" @change="updateGameSystem" />
                   <span class="slider round" ></span>
               </label>
-              <span class="age-toggle-label">Use Cthulhu Mythos</span>
+              <span class="age-toggle-label">Cthulhu Mythos</span>
               </div>
               <div class=" input-group" v-if="settings.gameSystem === 'fage1e' || settings.gameSystem === 'fage2e'">
               <label class="age-checkbox-toggle" style="margin:1rem;">
                   <input type="checkbox"  v-model="settings.technofantasy" @change="updateGameSystem" />
                   <span class="slider round" ></span>
               </label>
-              <span class="age-toggle-label">Use Technofantasy</span>
+              <span class="age-toggle-label">Technofantasy</span>
               </div>
             </div>
-          </div> -->
+          </div>
           <div class="row age-modal-row">
             <h4>System Options</h4>
             <div style="display: grid;grid-template-columns: repeat(3,1fr);">


### PR DESCRIPTION
…er Longarms)

When the Technofantasy genre slice is enabled, Blaster Pistols and Blaster Longarms now appear as weapon group options across WeaponGroupsModal, AttackModal, and InventoryModal. Also converts imperative ref+switch patterns to reactive computed properties in all three modals, and uncomments the Genre Slices section in SettingsView so the Technofantasy toggle is visible.
