### PR TITLE
fix(attack): correct Blue Rose / FAGE 2e weapon damage bonus calc

### DIFF
--- a/ageofficial/src/components/attack/AttackModal.vue
+++ b/ageofficial/src/components/attack/AttackModal.vue
@@ -174,7 +174,7 @@ const weaponGroups = computed(() => {
   return base;
 });
 const setWeaponGroupAbility = () => {
-    switch(props.item.weaponGroup){
+    switch(props.attack.weaponGroup){
       // ACCURACY
       case('Black Powder'):
       case('Bows'):
@@ -183,7 +183,7 @@ const setWeaponGroupAbility = () => {
       case('Light Blades'):
       case('Slings'):
       case('Staves'):
-        props.item.weaponGroupAbility = 'Accuracy';
+        props.attack.weaponGroupAbility = 'Accuracy';
       break;
       // FIGHTING
       case('Axes'):
@@ -192,10 +192,10 @@ const setWeaponGroupAbility = () => {
       case('Lances'):
       case('Polearms'):
       case('Spears'):
-        props.item.weaponGroupAbility = 'Fighting';
+        props.attack.weaponGroupAbility = 'Fighting';
       break;
       default:
-        props.item.weaponGroupAbility = ''
+        props.attack.weaponGroupAbility = ''
       break;
     }
 }

--- a/ageofficial/src/components/attack/CharacterAttack.vue
+++ b/ageofficial/src/components/attack/CharacterAttack.vue
@@ -166,25 +166,28 @@ const modsBonus = computed(() => {
     .filter(item => {
       return item.option === "Damage" && item.enabled
     });
-  const baseModifier = Number(mod)  || 0; // Calculate mod / 2 only once
+  const baseModifier = Number(mod)  || 0;
   const abilityBonus = ref(0);
+  // Untrained weapons inflict half damage (FAGE 2e). That halving is applied at roll
+  // time via the `trained` flag (see handlePrintDamage -> sumComponents/rollResults),
+  // so the damage string here is always the full, un-halved value.
   if(settings.gameSystem === 'fage2e' || settings.gameSystem === 'blue rose'){
-    if (char.weaponGroups.includes(props.attack.weaponGroup)) {
-      abilityBonus.value = Math.floor(Number(ability.abilityScores[props.attack.weaponGroupAbility === 'Fighting' ? 'Strength':'Perception']?.base) / 2) ;
-    } else if(props.attack.weaponType === 'Spell Ranged'){
-      abilityBonus.value = Math.floor(Number(ability.abilityScores[props.attack.weaponGroupAbility]?.base) / 2) ; 
+    if(props.attack.weaponType === 'Spell Ranged'){
+      abilityBonus.value = Number(ability.abilityScores[props.attack.weaponGroupAbility]?.base);
+    } else {
+      abilityBonus.value = Number(ability.abilityScores[props.attack.weaponGroupAbility === 'Fighting' ? 'Strength':'Perception']?.base);
     }
   } else {
-    abilityBonus.value = Number(ability.abilityScores[props.attack.weaponGroupAbility === 'Fighting' ? 'Strength':'Perception']?.base) ;    
+    abilityBonus.value = Number(ability.abilityScores[props.attack.weaponGroupAbility === 'Fighting' ? 'Strength':'Perception']?.base) ;
   }
   const totalModifiers = modifiersStore.reduce((total, item) => {
-    const value = item.bonus || item.penalty || 0; // Use bonus or penalty, default to 0 if neither
-    return total + Number(value); // Add each bonus or penalty without reapplying mod/2 or abilityBonus/2
+    const value = item.bonus || item.penalty || 0;
+    return total + Number(value);
   }, 0);
   const modifier = totalModifiers + baseModifier + abilityBonus.value;
   const sign = modifier >= 0 ? "+" : "-";
   if (modifier === 0) {
-    return base; // Just return the base value if the modifier is 0
+    return base;
   }
   return `${base}${sign}${Math.abs(modifier)}`;
 });

--- a/ageofficial/src/components/attack/WeaponGroupsModal.vue
+++ b/ageofficial/src/components/attack/WeaponGroupsModal.vue
@@ -39,7 +39,7 @@ const weaponGroups = computed(() => {
   switch (settings.gameSystem) {
     case 'mage':   base = mageWG;     break;
     case 'fage1e': base = fage1eWG;   break;
-    case 'bluerose': base = blueRoseWG; break;
+    case 'blue rose': base = blueRoseWG; break;
     case 'cthulhu': base = cthulhuWG; break;
     default:       base = fage2eWG;   break;
   }

--- a/ageofficial/src/rolltemplates/expressions/sumComponents.ts
+++ b/ageofficial/src/rolltemplates/expressions/sumComponents.ts
@@ -3,8 +3,8 @@ import type { DiceComponent } from '../rolltemplates';
 export const sumComponents = (components: DiceComponent[], multiplier = 1) => {
   let sum = components.reduce((sum, component) => sum + (component.value ?? 0), 0) * multiplier;
   if (components[0] && components[0].trained === false) {
-    console.log
-    sum = Math.ceil(sum / 2);
+    // Untrained weapons inflict half damage, rounded down (FAGE 2e).
+    sum = Math.floor(sum / 2);
   }
   return sum;
 };


### PR DESCRIPTION
Previously the ability bonus added to weapon damage was halved in the sheet, while untrained weapons were also halved (rounded up) at roll time, producing incorrect totals. Use the full ability score for the damage string and apply the untrained half-damage halving solely at roll time (rounded down, per FAGE 2e).
