### PR TITLE
Dw focuses alphabetical order

### DIFF
--- a/ageofficial/src/App.vue
+++ b/ageofficial/src/App.vue
@@ -20,19 +20,19 @@
                   </button>
                 </div>
                 <div class="age-header-btn">
-                  <button v-if="settings.aimToggle === 'toggle'" :class="{ active: settings.aim }" class="age-btn" @click="updateToggle;settings.aim = !settings.aim">
+                  <button v-if="settings.aimToggle === 'toggle'" :class="{ active: settings.aim }" class="age-btn" @click="settings.aim = !settings.aim">
                     <div class="age-toggle-btn-icon age-toggle-aim-icon"></div>
                     <span>Aim</span>
                   </button>
                 </div>
                 <div class="age-header-btn">
-                  <button v-if="settings.guardToggle === 'toggle'" :class="{ active: settings.guard }" class="age-btn" @click="settings.guard = !settings.guard">
+                  <button v-if="settings.guardToggle === 'toggle'" :class="{ active: settings.guard }" class="age-btn" @click="settings.guard = !settings.guard;">
                     <div class="age-toggle-btn-icon age-toggle-guard-icon"></div>
                     <span>Guard</span>
                   </button>
                 </div>
                 <div class="age-header-btn">
-                  <button v-if="settings.rerollStunt === 'toggle'" :class="{ active: settings.reroll  }" class="age-btn" @click="settings.reroll = !settings.reroll">
+                  <button v-if="settings.rerollStunt === 'toggle'" :class="{ active: settings.reroll  }" class="age-btn" @click="settings.reroll = !settings.reroll;">
                     <div class="age-toggle-btn-icon age-toggle-reroll-icon"></div>
                     <span>ReRoll</span>
                   </button>
@@ -62,25 +62,25 @@
               <div class="dropdown" style="text-align: right;">
                 <ul class="dropdown-menu">
                   <li>
-                    <button v-if="settings.whisperRollsGM === 'toggle'" :class="{ active: settings.whisperRollsGMToggle }" class="age-btn" @click="settings.whisperRollsGMToggle = !settings.whisperRollsGMToggle">
+                    <button v-if="settings.whisperRollsGM === 'toggle'" :class="{ active: settings.whisperRollsGMToggle }" class="age-btn" @click="settings.whisperRollsGMToggle = !settings.whisperRollsGMToggle;">
                     <div class="age-toggle-btn-icon age-toggle-whisper-icon"></div>
                     <span>Whisper</span>
                   </button>
                   </li>
                   <li>
-                    <button v-if="settings.aimToggle === 'toggle'" :class="{ active: settings.aim }" class="age-btn" @click="updateToggle;settings.aim = !settings.aim">
+                    <button v-if="settings.aimToggle === 'toggle'" :class="{ active: settings.aim }" class="age-btn" @click="settings.aim = !settings.aim">
                     <div class="age-toggle-btn-icon age-toggle-aim-icon"></div>
                     <span>Aim</span>
                   </button>
                   </li>
                   <li>
-                    <button v-if="settings.guardToggle === 'toggle'" :class="{ active: settings.guard }" class="age-btn" @click="settings.guard = !settings.guard">
+                    <button v-if="settings.guardToggle === 'toggle'" :class="{ active: settings.guard }" class="age-btn" @click="settings.guard = !settings.guard;">
                     <div class="age-toggle-btn-icon age-toggle-guard-icon"></div>
                     <span>Guard</span>
                   </button>
                   </li>
                   <li>
-                    <button v-if="settings.rerollStunt === 'toggle'" :class="{ active: settings.reroll  }" class="age-btn" @click="settings.reroll = !settings.reroll">
+                    <button v-if="settings.rerollStunt === 'toggle'" :class="{ active: settings.reroll  }" class="age-btn" @click="settings.reroll = !settings.reroll;">
                     <div class="age-toggle-btn-icon age-toggle-reroll-icon"></div>
                     <span>ReRoll</span>
                   </button>

--- a/ageofficial/src/components/abilities/AbilityCheckModal.vue
+++ b/ageofficial/src/components/abilities/AbilityCheckModal.vue
@@ -161,6 +161,12 @@ function combineObjects(array) {
     }
   });
 
+  result.sort((a, b) => {
+    const aName = String(a.name ?? '');
+    const bName = String(b.name ?? '');
+    return aName < bName ? -1 : aName > bName ? 1 : 0;
+  });
+
   return result;
 }
 </script>

--- a/ageofficial/src/components/qualities/QualitiesClassSection.vue
+++ b/ageofficial/src/components/qualities/QualitiesClassSection.vue
@@ -9,7 +9,7 @@
       <h5 class="mt-3">{{ quality }}</h5>
       <div class="accordion age-accordion">        
         <CharacterQualitiesView
-          v-for="(qty, index) in item.items.filter(item => getQuality(quality).includes(item.type))"
+          v-for="(qty, index) in sortedItemsByQuality[quality]"
           :type="quality"
           :key="qty._id"
           :feature="qty"
@@ -29,7 +29,8 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
 import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 import QualitiesModal from './QualitiesModal.vue';
@@ -68,6 +69,29 @@ let featureNew = ref({
   modifiers:[]
   })
 const item = useItemStore();
+const { items: qualityItems } = storeToRefs(item);
+
+const sortedItemsByQuality = computed(() => {
+  const allItems = [...qualityItems.value];
+  return Object.fromEntries(
+    qualitiesArray.value.map((quality) => {
+      const types = getQuality(quality);
+      const filtered = allItems.filter((i) => types.includes(i.type));
+      if (quality === 'Ability Focus') {
+        filtered.sort((a, b) => {
+          const aAbility = String(a.ability ?? '');
+          const bAbility = String(b.ability ?? '');
+          if (aAbility !== bAbility) return aAbility < bAbility ? -1 : 1;
+          const aName = String(a.name ?? '');
+          const bName = String(b.name ?? '');
+          return aName < bName ? -1 : aName > bName ? 1 : 0;
+        });
+      }
+      return [quality, filtered];
+    })
+  );
+});
+
 function resetFeature(){
   featureNew.value = {
   type: '',

--- a/ageofficial/src/components/qualities/QualitiesSection.vue
+++ b/ageofficial/src/components/qualities/QualitiesSection.vue
@@ -75,6 +75,7 @@ import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
 import { computed, reactive, ref } from 'vue';
 import QualitiesModal from './QualitiesModal.vue';
 import CharacterQualitiesView from './CharacterQualitiesView.vue';
+
 const props = defineProps({
   aim: { type: Boolean },
   aimValue: { type: Number },
@@ -152,12 +153,13 @@ function getItemType(type){
   return filteredType
 }
 function getQuality(quality) {
-  if (quality === 'Ancestry & Class') {    
+  if (quality === 'Ancestry & Class') {
     return ['Ancestry', 'Class'];
   } else {
     return [quality];  // Return as an array to simplify the filter logic
   }
 }
+
 </script>
 
 <style scoped lang="scss">

--- a/ageofficial/src/sheet/stores/modifiersCheck/abilities.ts
+++ b/ageofficial/src/sheet/stores/modifiersCheck/abilities.ts
@@ -10,12 +10,6 @@ export const abilityMods = computed(() => {
         console.log(mod)
         values.push({ability:mod.modifiedValue, name:mod.abilityFocus,variable:mod.bonus || mod.penalty || 0})
       }
-  })
-  console.log(values)
-  return values
-//   if(values.length > 0){
-//     return values.reduce(function(a,b){return a+b;})
-//   } else {
-//     return 0
-//   }
+    });
+  return values;
 })

--- a/ageofficial/src/views/PCView.vue
+++ b/ageofficial/src/views/PCView.vue
@@ -125,7 +125,6 @@ import InventorySection from '@/components/inventory/InventorySection.vue';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 import MagicSection from '@/components/magic/MagicSection.vue';
 import XPSection from '@/components/XPSection.vue';
-import QualitySection from '@/components/qualities/QualitiesSection.vue';
 import QualityClassSection from '@/components/qualities/QualitiesClassSection.vue';
 import QualityTalentSection from '@/components/qualities/QualitiesTalentSection.vue';
 import DefenseView from '@/components/DefenseView.vue';


### PR DESCRIPTION
Ability Focus items in QualitiesClassSection now display sorted alphabetically — first by ability score (e.g. Accuracy before Fighting), then by focus name within the same ability. Uses a storeToRefs-backed computed to ensure the sort reacts correctly after store hydration.

Focus buttons in AbilityCheckModal are also now sorted alphabetically by focus name.

Also removes a reference to the undefined updateToggle function from the Aim toggle click handlers in App.vue (was causing vue-tsc errors), and removes the dead import of QualitiesSection from PCView.vue.