### PR TITLE
feat(focuses): add genre-slice-specific focuses

### DIFF
--- a/ageofficial/src/components/abilities/AbilityCheckModal.vue
+++ b/ageofficial/src/components/abilities/AbilityCheckModal.vue
@@ -35,7 +35,7 @@ import { useAbilityFocusesStore } from '@/sheet/stores/abilityScores/abilityFocu
 import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 // import { defineEmits } from 'vue';
-import { mage, fage2e, bluerose,fage1e, cthulhu } from '../modifiers/focuses';
+import { resolveFocuses } from '../modifiers/focuses';
 import { abilityMods } from '@/sheet/stores/modifiersCheck/abilities';
 
 const { abilityScores, rollAbilityCheck } = useAbilityScoreStore();
@@ -45,25 +45,9 @@ const emit = defineEmits(['rerollCheck']);
 const abilityFocusArray = ref(
   [...quality.items.filter(foc => foc.ability === props.ability),...abilityMods.value.filter(am => am.ability === props.ability)]
 );
-const filteredFocuses = ref(fage2e)
-
-switch(useSettingsStore().gameSystem){
-  case 'fage2e':
-    filteredFocuses.value = fage2e;
-  break;
-  case 'mage':
-    filteredFocuses.value = mage;
-  break;
-  case 'fage1e':
-    filteredFocuses.value = fage1e;
-  break;
-  case 'bluerose':
-    filteredFocuses.value = bluerose;
-  break;
-  case 'cthulhu':
-    filteredFocuses.value = cthulhu;
-  break;
-}
+const settings = useSettingsStore();
+// Base focuses for the system, merged with any active genre-slice focuses.
+const filteredFocuses = computed(() => resolveFocuses(settings.gameSystem, settings));
 // const combinedArray = Object.entries(filteredFocuses).flatMap(([ability, names]) => {
 //     return names.map(name => {
 //         const matchingFocus = abilityFocusArray.value.find(item => item.ability === ability && item.name === name);

--- a/ageofficial/src/components/modifiers/AbilityModView.vue
+++ b/ageofficial/src/components/modifiers/AbilityModView.vue
@@ -44,32 +44,16 @@
     </div>
 </template>
 <script setup>
-import { ref } from 'vue';
+import { computed } from 'vue';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
-import { bluerose, cthulhu, fage1e, fage2e, mage } from '@/components/modifiers/focuses'
+import { resolveFocuses } from '@/components/modifiers/focuses'
 
 const props = defineProps({
     mod:{ type: Object}
 })
+const settings = useSettingsStore();
 const abilities = ['Accuracy', 'Communication','Constitution','Dexterity','Fighting','Intelligence','Perception','Strength','Willpower']
 
-const filteredFocuses = ref()
-
-switch(useSettingsStore().gameSystem){
-  case 'fage2e':
-    filteredFocuses.value = fage2e;
-  break;
-  case 'mage':
-    filteredFocuses.value = mage;
-  break;
-  case 'fage1e':
-    filteredFocuses.value = fage1e;
-  break;
-  case 'bluerose':
-    filteredFocuses.value = bluerose;
-  break;
-  case 'cthulhu':
-    filteredFocuses.value = cthulhu;
-  break;
-}
+// Base focuses for the system, merged with any active genre-slice focuses.
+const filteredFocuses = computed(() => resolveFocuses(settings.gameSystem, settings));
 </script>

--- a/ageofficial/src/components/modifiers/focuses.ts
+++ b/ageofficial/src/components/modifiers/focuses.ts
@@ -446,6 +446,54 @@ export const bluerose = {
   ],
 };
 
+// Genre-slice-specific focuses. Each slice is gated by its settings flag (see
+// SLICE_FOCUS_GROUPS in QualitiesModal.vue) and rendered as its own optgroup in the
+// focus picker, mirroring how technofantasyWG augments weapon groups.
+// TODO(1212542321995877): populate each slice's focuses + abilities from the design sheet
+// (skip Eldritch Arcane focuses per the ticket).
+// Each slice maps ability -> focuses. The special "Arcana" key feeds the Arcana optgroup
+// (school name only, rendered as "Arcana (X)"); all other keys are plain ability focuses.
+// "Arcana" focuses feed the Arcana optgroup, "Psychic" the Psychic optgroup (school/power
+// name only). All other keys are plain ability focuses shown under the slice's own optgroup.
+type SliceFocusMap = Record<string, string[]>;
+const emptySlice = (): SliceFocusMap => ({
+  Accuracy: [], Communication: [], Constitution: [], Dexterity: [], Fighting: [],
+  Intelligence: [], Perception: [], Strength: [], Willpower: [], Arcana: [], Psychic: [],
+});
+export const sliceFocuses: Record<string, SliceFocusMap> = {
+  technofantasy: {
+    ...emptySlice(),
+    Accuracy: ['Blaster Longarms', 'Blaster Pistols'],
+    Dexterity: ['Advanced Driving', 'Advanced Piloting'],
+    Intelligence: ['Computer Lore', 'Scientific Lore'],
+    Strength: ['Machining'],
+    Arcana: ['Digital', 'Machine'],
+  },
+  cthulhuMythos: {
+    ...emptySlice(),
+    // Eldritch Arcana intentionally omitted per ticket 1212542321995877.
+    Arcana: ['Astral', 'Drain', 'Radiant', 'Spatial'],
+  },
+  cyberpunk: {
+    ...emptySlice(),
+    Accuracy: ['Virtuality', 'Drone Weaponry'],
+    Dexterity: ['Remote Operation'],
+    Fighting: ['Exoskeleton'],
+    Intelligence: ['Cybernetics', 'Streetwise', 'Synthlife'],
+    Perception: ['Codefinding', 'Survival'],
+  },
+  threefold: {
+    ...emptySlice(),
+    Arcana: ['Death', 'Enchantment', 'Luck', 'Radiant'],
+    Psychic: ['Apportation', 'Astral', 'Dreaming', 'Somatic'],
+  },
+  powers: {
+    ...emptySlice(),
+    Arcana: ['Death', 'Enchantment', 'Geomancy', 'Gravity', 'Radio', 'Transmutation', 'Virtual'],
+    Psychic: ['Apportation', 'Astral', 'Cyberkinesis', 'Dreaming', 'Electronkinesis', 'Nature Empathy', 'Photokinesis', 'Psychic Drain', 'Serendipity', 'Somatic'],
+  },
+};
+
 export const expanse = {
   Accuracy: ["Bows", "Gunnery", "Pistols", "Rifles", "Throwing"],
   Communication: [
@@ -505,3 +553,60 @@ export const expanse = {
   Strength: ["Climbing", "Intimidation", "Jumping", "Might"],
   Willpower: ["Courage", "Faith", "Self-Discipline"],
 };
+
+// ---- Slice resolution helpers ----------------------------------------------
+// Each genre slice + the settings flag that activates it. Single source of truth
+// shared by every focus picker (QualitiesModal, AbilityModView, AbilityCheckModal, ...).
+export const SLICE_DEFS = [
+  { key: 'technofantasy', label: 'Technofantasy',  flag: 'technofantasy' },
+  { key: 'cthulhuMythos', label: 'Cthulhu Mythos', flag: 'cthulhuMythos' },
+  { key: 'cyberpunk',     label: 'Cyber',          flag: 'cyberpunk' },
+  { key: 'threefold',     label: 'Threefold',      flag: 'threefold' },
+  { key: 'powers',        label: 'Powers',         flag: 'powers' },
+];
+
+// Base per-ability focus list for a game system.
+export function baseFocusMap(gameSystem?: string): SliceFocusMap {
+  switch (gameSystem) {
+    case 'fage1e':    return fage1e;
+    case 'mage':      return mage;
+    case 'blue rose': return bluerose;
+    case 'cthulhu':   return cthulhu;
+    case 'expanse':   return expanse;
+    case 'fage2e':
+    default:          return fage2e;
+  }
+}
+
+// Merge active slices' plain ability focuses into a base map. Arcana/Psychic keys are
+// intentionally excluded here -- those feed their own optgroups.
+export function mergeSliceFocuses(
+  base: SliceFocusMap,
+  isActive: (sliceKey: string) => boolean,
+): SliceFocusMap {
+  const merged: SliceFocusMap = {};
+  for (const ability of Object.keys(base)) merged[ability] = [...base[ability]];
+  for (const def of SLICE_DEFS) {
+    if (!isActive(def.key)) continue;
+    const slice = sliceFocuses[def.key];
+    if (!slice) continue;
+    for (const ability of Object.keys(slice)) {
+      if (ability === 'Arcana' || ability === 'Psychic') continue;
+      if (!slice[ability].length) continue;
+      merged[ability] = [...(merged[ability] || []), ...slice[ability]];
+    }
+  }
+  // Keep each ability's focus list alphabetical after merging in slice focuses.
+  for (const ability of Object.keys(merged)) {
+    merged[ability] = merged[ability].sort((a, b) => a.localeCompare(b));
+  }
+  return merged;
+}
+
+// Convenience: base focuses for `gameSystem` merged with whatever slices are on in `flags`.
+export function resolveFocuses(gameSystem: string | undefined, flags: Record<string, any>): SliceFocusMap {
+  return mergeSliceFocuses(baseFocusMap(gameSystem), (key) => {
+    const def = SLICE_DEFS.find((d) => d.key === key);
+    return !!(def && flags[def.flag]);
+  });
+}

--- a/ageofficial/src/components/qualities/QualitiesModal.vue
+++ b/ageofficial/src/components/qualities/QualitiesModal.vue
@@ -62,7 +62,7 @@
                           {{ option }}
                         </option>
                       </optgroup>
-                      <optgroup label="Psychic" v-if="feature.ability === 'Intelligence' && settings.gameSystem === 'mage'">
+                      <optgroup label="Psychic" v-if="feature.ability === 'Intelligence' && psychicFocuses.length">
                         <option
                           v-for="option in psychicFocuses"
                           :key="`Psychic-${option}`"
@@ -354,7 +354,7 @@ import { useCharacterStore } from '@/sheet/stores/character/characterStore';
 import { v4 as uuidv4 } from 'uuid';
 import SpellModView from '@/components/modifiers/SpellModView.vue';
 import AbilityModView from '@/components/modifiers/AbilityModView.vue';
-import { arcaneFocusNames, bluerose, cthulhu, expanse, fage1e, fage2e, mage } from '../modifiers/focuses';
+import { arcaneFocusNames, sliceFocuses, SLICE_DEFS, resolveFocuses } from '../modifiers/focuses';
 import CustomAttackModView from '../modifiers/CustomAttackModView.vue';
 import {useModifiersStore} from '@/sheet/stores/modifiers/modifiersStore'
 import BaseModView from '@/components/modifiers/BaseModView.vue';
@@ -371,29 +371,33 @@ const mods = useModifiersStore();
 const settings = useSettingsStore()
 const abilities = ['Accuracy', 'Communication','Constitution','Dexterity','Fighting','Intelligence','Perception','Strength','Willpower'];
 // mods.modifiers = [];
+// Genre slices that are currently toggled on (definitions/flags shared via SLICE_DEFS).
+const activeSlices = () => SLICE_DEFS.filter((s) => settings[s.flag]);
+
 const arcanaFocuses = computed(() => {
+  let base;
   switch (settings.gameSystem) {
     case 'fage2e':
     case 'fage1e':
-    case 'cthulhu': return fageArcana;
-    case 'mage':    return magePowers;
-    case 'blue rose': return brArcana;
-    default: return [];
+    case 'cthulhu': base = fageArcana; break;
+    case 'mage':    base = magePowers; break;
+    case 'blue rose': base = brArcana; break;
+    default: base = []; break;
   }
+  // Append Arcana focuses contributed by any active genre slice, kept alphabetical.
+  const sliceArcana = activeSlices().flatMap((s) => sliceFocuses[s.key]?.Arcana || []);
+  return [...base, ...sliceArcana].sort((a, b) => a.localeCompare(b));
 });
-const psychicFocuses = computed(() => settings.gameSystem === 'mage' ? magePsychicPowers : []);
-
+const psychicFocuses = computed(() => {
+  const base = settings.gameSystem === 'mage' ? magePsychicPowers : [];
+  // Append Psychic focuses contributed by any active genre slice (e.g. Threefold, Powers).
+  const slicePsychic = activeSlices().flatMap((s) => sliceFocuses[s.key]?.Psychic || []);
+  return [...base, ...slicePsychic].sort((a, b) => a.localeCompare(b));
+});
 const filteredFocuses = computed(() => {
-  let base;
-  switch (settings.gameSystem) {
-    case 'fage2e':    base = fage2e;    break;
-    case 'mage':      base = mage;      break;
-    case 'fage1e':    base = fage1e;    break;
-    case 'blue rose': base = bluerose;  break;
-    case 'cthulhu':   base = cthulhu;   break;
-    case 'expanse':   base = expanse;   break;
-    default:          base = fage2e;    break;
-  }
+  // Base focuses for the system, with any active genre-slice focuses merged straight
+  // into each ability's list (Arcana/Psychic slice focuses are handled by their own groups).
+  const base = resolveFocuses(settings.gameSystem, settings);
   if (!settings.showArcana) {
     return Object.fromEntries(
       Object.entries(base).map(([ability, focuses]) => [

--- a/ageofficial/src/sheet/stores/settings/settingsStore.ts
+++ b/ageofficial/src/sheet/stores/settings/settingsStore.ts
@@ -28,6 +28,8 @@ export type SettingsHydrate = {
     showArcana:boolean;
     cyberpunk:boolean;
     technofantasy:boolean;
+    threefold:boolean;
+    powers:boolean;
     showFear:boolean;
     showAlienation:boolean;
     showCybernetics:boolean;
@@ -66,6 +68,8 @@ export const useSettingsStore = defineStore('settings', () => {
   const showArcana = ref(false);
   const cyberpunk = ref(false);
   const technofantasy = ref(false);
+  const threefold = ref(false);
+  const powers = ref(false);
   const showFear = ref(false);
   const showAlienation = ref(false);
   const showCybernetics = ref(false);
@@ -104,6 +108,8 @@ export const useSettingsStore = defineStore('settings', () => {
         showArcana:showArcana.value,
         cyberpunk:cyberpunk.value,
         technofantasy: technofantasy.value,
+        threefold: threefold.value,
+        powers: powers.value,
         showFear: showFear.value,
         showAlienation: showAlienation.value,
         showCybernetics: showCybernetics.value,
@@ -143,6 +149,8 @@ export const useSettingsStore = defineStore('settings', () => {
     showArcana.value = hydrateStore.settings.showArcana ?? showArcana.value
     cyberpunk.value = hydrateStore.settings.cyberpunk ?? cyberpunk.value
     technofantasy.value = hydrateStore.settings.technofantasy ?? technofantasy.value
+    threefold.value = hydrateStore.settings.threefold ?? threefold.value
+    powers.value = hydrateStore.settings.powers ?? powers.value
     showFear.value = hydrateStore.settings.showFear ?? showFear.value
     showAlienation.value = hydrateStore.settings.showAlienation ?? showAlienation.value
     showCybernetics.value = hydrateStore.settings.showCybernetics ?? showCybernetics.value
@@ -180,6 +188,8 @@ export const useSettingsStore = defineStore('settings', () => {
     showArcana,
     cyberpunk,
     technofantasy,
+    threefold,
+    powers,
     showFear,
     showAlienation,
     showCybernetics,

--- a/ageofficial/src/views/SettingsView.vue
+++ b/ageofficial/src/views/SettingsView.vue
@@ -48,7 +48,7 @@
           <!-- // TODO Items unique to genre slices. Technofantasy, Cthulhu Awakens, Cyberpunk, etc. -->
           <div class="row age-modal-row"  v-if="settings.gameSystem === 'fage1e' || settings.gameSystem === 'fage2e' || settings.gameSystem === 'cthulhu' || settings.gameSystem === 'mage'">
             <h4>Genre Slices</h4>
-            <div style="display: grid;grid-template-columns: repeat(2,1fr);">
+            <div style="display: grid;grid-template-columns: repeat(3,1fr);">
               <div class=" input-group" v-if="settings.gameSystem === 'mage'">
                 <label class="age-checkbox-toggle" style="margin:1rem;">
                     <input type="checkbox"  v-model="settings.cyberpunk" @change="updateGameSystem" />
@@ -69,6 +69,20 @@
                   <span class="slider round" ></span>
               </label>
               <span class="age-toggle-label">Technofantasy</span>
+              </div>
+              <div class=" input-group" v-if="settings.gameSystem === 'mage'">
+              <label class="age-checkbox-toggle" style="margin:1rem;">
+                  <input type="checkbox"  v-model="settings.threefold" @change="updateGameSystem" />
+                  <span class="slider round" ></span>
+              </label>
+              <span class="age-toggle-label">Threefold</span>
+              </div>
+              <div class=" input-group" v-if="settings.gameSystem === 'mage'">
+              <label class="age-checkbox-toggle" style="margin:1rem;">
+                  <input type="checkbox"  v-model="settings.powers" @change="updateGameSystem" />
+                  <span class="slider round" ></span>
+              </label>
+              <span class="age-toggle-label">Powers</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Show slice-specific focuses in the focus pickers when a genre slice is toggled in settings (Asana 1212542321995877).

- focuses.ts: sliceFocuses data for Technofantasy, Cthulhu Mythos, Cyber, Threefold, and Powers (Eldritch Arcana omitted per ticket); shared SLICE_DEFS + baseFocusMap + mergeSliceFocuses + resolveFocuses helper that merges active slices' focuses into each ability list, sorted alphabetically.
- settingsStore: add threefold and powers slice flags (hydrate/dehydrate).
- SettingsView: add Threefold and Powers toggles (Modern AGE slices).
- QualitiesModal / AbilityModView / AbilityCheckModal: route focus lists through resolveFocuses so slice focuses merge inline; slice Arcana and Psychic focuses fold into the existing Arcana/Psychic groups.
- Incidentally fixes a 'bluerose' vs 'blue rose' typo that gave Blue Rose empty focus lists in the modifier/ability-check pickers.