### PR TITLE
feat(focus): add Expertise (focus) talents

### DIFF
--- a/ageofficial/src/components/modifiers/BaseModView.vue
+++ b/ageofficial/src/components/modifiers/BaseModView.vue
@@ -11,6 +11,7 @@
   <DamageModView v-if="mod.option === 'Damage'" :mod="mod" />
   <DefenseModView v-if="mod.option === 'Defense'" :mod="mod" />
   <AbilityModView v-if="mod.option === 'Ability Reroll' || mod.option === 'Ability'" :mod="mod" />
+  <ExpertiseModView v-if="mod.option === 'Expertise'" :mod="mod" />
   <SpellModView v-if="mod.option === 'Spell'" :mod="mod" />
   <SpeedModView v-if="mod.option === 'Speed'" :mod="mod" />
   <ArmorModView v-if="mod.option === 'Armor Rating' || mod.option === 'Armor Penalty'" :mod="mod" />
@@ -26,6 +27,7 @@
 import DamageModView from './DamageModView.vue';
 import SpellModView from '@/components/modifiers/SpellModView.vue';
 import AbilityModView from '@/components/modifiers/AbilityModView.vue';
+import ExpertiseModView from '@/components/modifiers/ExpertiseModView.vue';
 import DefenseModView from '@/components/modifiers/DefenseModView.vue';
 import CustomAttackModView from '../modifiers/CustomAttackModView.vue';
 import { useModifiersStore } from '@/sheet/stores/modifiers/modifiersStore';

--- a/ageofficial/src/components/modifiers/ExpertiseModView.vue
+++ b/ageofficial/src/components/modifiers/ExpertiseModView.vue
@@ -1,0 +1,78 @@
+<template>
+  <div style="display:flex;gap:10px;width:100%;align-items:center;">
+    <!-- existing focus (prerequisite) | sub-focus label | Bonus(auto +1)/Reroll -->
+    <select
+      class="age-atk-select form-select"
+      style="flex:1;"
+      data-testid="test-expertise-focus"
+      v-model="selectedFocusId"
+    >
+      <option value="">Select a focus…</option>
+      <option v-for="f in focusOptions" :key="f._id" :value="f._id">{{ f.label }}</option>
+    </select>
+    <input
+      type="text"
+      class="form-control"
+      style="flex:1;"
+      placeholder="Sub-focus (e.g. Ghosts)"
+      v-model="mod.field"
+    />
+    <select
+      class="age-atk-select form-select"
+      style="flex:1;"
+      data-testid="test-expertise-effect"
+      v-model="mod.modifiedOption"
+    >
+      <option value="Bonus">Bonus</option>
+      <option value="Reroll">Reroll</option>
+    </select>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, watch } from 'vue';
+import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
+
+const props = defineProps({
+  mod: { type: Object },
+});
+const itemStore = useItemStore();
+
+// Expertise requires an existing focus, so the user only picks from focuses they have.
+const focusOptions = computed(() =>
+  itemStore.items
+    .filter((i) => i.type === 'Ability Focus')
+    .map((f) => {
+      const name = f.name === 'custom' ? f.customName : f.name;
+      return { _id: f._id, name, ability: f.ability, label: `${name} (${f.ability})` };
+    }),
+);
+
+// The dropdown is keyed by the focus item's id, but the modifier stores the focus name
+// (abilityFocus) + ability (modifiedValue) so it matches the focus row.
+const selectedFocusId = computed({
+  get() {
+    const match = focusOptions.value.find(
+      (f) => f.name === props.mod.abilityFocus && f.ability === props.mod.modifiedValue,
+    );
+    return match ? match._id : '';
+  },
+  set(id) {
+    const f = focusOptions.value.find((x) => x._id === id);
+    props.mod.abilityFocus = f ? f.name : '';
+    props.mod.modifiedValue = f ? f.ability : '';
+  },
+});
+
+// Expertise defaults to a fixed +1 Bonus (no value input).
+onMounted(() => {
+  if (!props.mod.modifiedOption) props.mod.modifiedOption = 'Bonus';
+});
+watch(
+  () => props.mod.modifiedOption,
+  (opt) => {
+    if (opt === 'Bonus') props.mod.bonus = 1;
+  },
+  { immediate: true },
+);
+</script>

--- a/ageofficial/src/components/qualities/ExpertiseRow.vue
+++ b/ageofficial/src/components/qualities/ExpertiseRow.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="accordion-item age-expertise-row">
+    <div class="accordion-header attack attack__row age-qualities-accordion-header">
+      <div style="display: flex;position: relative;">
+        <div class="age-quality-section age-quality-focus-icon"></div>
+      </div>
+      <div class="label">
+        <div>
+          {{ focusName }}<span v-if="expertise.field">: {{ expertise.field }}</span><br />
+        </div>
+        <span v-if="focus.ability">({{ focus.ability }})</span>
+        <span class="age-expertise-tag">Expertise</span>
+      </div>
+
+      <div class="age-weapon-range-reload">
+        <div style="display: grid;align-items: center;height: 100%;">
+          <button
+            class="age-btn"
+            v-tippy="{ content: `${focusName}${expertise.field ? ' : ' + expertise.field : ''} Expertise` }"
+            @click="rollExpertise()"
+          >
+            +{{ total }}
+            <font-awesome-icon :icon="['fa', 'dice']" style="margin-left:3px;" />
+          </button>
+        </div>
+      </div>
+      <div class="age-weapon-btn-container">
+        <button
+          v-if="hasReroll"
+          class="age-btn age-icon-btn"
+          v-tippy="{ content: 'Expert: reroll a failed test (keep the second result)' }"
+          @click="rollExpertise()"
+        >
+          <font-awesome-icon :icon="['fa', 'rotate']" />
+        </button>
+      </div>
+
+      <button type="button" class="config-btn age-icon-btn" @click="handlePrint" v-tippy="{ content: 'Share Expertise in chat' }">
+        <font-awesome-icon :icon="['fa', 'comment']" />
+      </button>
+      <div style="display: grid;align-items: center;grid-template-columns: 1fr;height: 100%;">
+        <button type="button" class="config-btn age-icon-btn" @click="showModal = true" v-tippy="{ content: 'Edit Talent' }">
+          <font-awesome-icon :icon="['fa', 'gear']" />
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <Teleport to="body">
+    <QualitiesModal
+      v-if="parentTalent"
+      :show="showModal"
+      :feature="parentTalent"
+      :index="0"
+      @close="showModal = false"
+      @delete="handleDelete"
+    >
+      <template #header>
+        <h3 class="age-modal-details-header">Talent Details</h3>
+      </template>
+    </QualitiesModal>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { useAbilityScoreStore } from '@/sheet/stores/abilityScores/abilityScoresStore';
+import { useModifiersStore } from '@/sheet/stores/modifiers/modifiersStore';
+import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
+import QualitiesModal from './QualitiesModal.vue';
+
+const props = defineProps({
+  // The Ability-Bonus modifier that defines this expertise.
+  expertise: { type: Object, required: true },
+  // The parent Ability Focus item this expertise refines.
+  focus: { type: Object, required: true },
+});
+
+const { rollAbilityCheck } = useAbilityScoreStore();
+const showModal = ref(false);
+
+// Custom focuses store name === 'custom' with the real name in customName.
+const focusName = computed(() => (props.focus.name === 'custom' ? props.focus.customName : props.focus.name));
+
+// The Talent this expertise modifier belongs to (its edit gear opens this Talent).
+const parentTalent = computed(() => useItemStore().getItem(props.expertise.parentId));
+
+// Focus bonus from the underlying focus (+4 double focus, +2 focus, else 0).
+const focusBonus = (f) => (f.doubleFocus ? 4 : f.focus ? 2 : 0);
+const expertiseBonus = computed(() => Number(props.expertise.bonus) || 0);
+
+const total = computed(() =>
+  Number(useAbilityScoreStore().abilityScores[props.focus.ability]?.base || 0)
+  + focusBonus(props.focus)
+  + expertiseBonus.value,
+);
+
+// Expert tier: a sibling Reroll modifier on the same focus enables the reroll affordance.
+const hasReroll = computed(() =>
+  useModifiersStore().modifiers.some((m) =>
+    m.enabled !== false
+    && m.modifiedOption === 'Reroll'
+    && m.abilityFocus === focusName.value
+    && m.modifiedValue === props.focus.ability,
+  ),
+);
+
+const rollExpertise = () => {
+  const label = `${focusName.value}${props.expertise.field ? ': ' + props.expertise.field : ''}`;
+  rollAbilityCheck(
+    props.focus.ability,
+    true,
+    focusBonus(props.focus) + expertiseBonus.value,
+    { name: label },
+  );
+};
+
+const handlePrint = () => {
+  if (props.expertise.parentId) useItemStore().printQuality(props.expertise.parentId);
+};
+
+const handleDelete = () => {
+  showModal.value = false;
+  if (props.expertise.parentId) useItemStore().removeItem(props.expertise.parentId);
+};
+</script>
+
+<style scoped>
+.age-expertise-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 16px;
+  padding: 0 8px;
+  margin: 0 0 2px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  /* compensate the trailing letter-spacing so the glyphs read horizontally centered */
+  text-indent: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--theme-primary, #1e4e7a);
+  border-radius: 999px;
+  vertical-align: middle;
+}
+.age-expertise-row .label > div {
+  font-weight: 600;
+}
+</style>

--- a/ageofficial/src/components/qualities/QualitiesClassSection.vue
+++ b/ageofficial/src/components/qualities/QualitiesClassSection.vue
@@ -8,14 +8,20 @@
     <div v-for="quality in qualitiesArray" :key="quality" >
       <h5 class="mt-3">{{ quality }}</h5>
       <div class="accordion age-accordion">        
-        <CharacterQualitiesView
-          v-for="(qty, index) in sortedItemsByQuality[quality]"
-          :type="quality"
-          :key="qty._id"
-          :feature="qty"
-          :id="qty._id"
-          :index="index"
-        />
+        <template v-for="(qty, index) in sortedItemsByQuality[quality]" :key="qty._id">
+          <CharacterQualitiesView
+            :type="quality"
+            :feature="qty"
+            :id="qty._id"
+            :index="index"
+          />
+          <ExpertiseRow
+            v-for="exp in expertisesForFocus(qty)"
+            :key="exp._id"
+            :expertise="exp"
+            :focus="qty"
+          />
+        </template>
       </div>
     </div>
   </div>
@@ -35,6 +41,22 @@ import { useItemStore } from '@/sheet/stores/character/characterQualitiesStore';
 import { useSettingsStore } from '@/sheet/stores/settings/settingsStore';
 import QualitiesModal from './QualitiesModal.vue';
 import CharacterQualitiesView from './CharacterQualitiesView.vue';
+import ExpertiseRow from './ExpertiseRow.vue';
+import { useModifiersStore } from '@/sheet/stores/modifiers/modifiersStore';
+
+// An expertise is an Ability bonus modifier (typically on a Talent) scoped to a focus
+// the character has. Render one row per expertise beneath its parent focus.
+function expertisesForFocus(item) {
+  if (item.type !== 'Ability Focus') return [];
+  const focusName = item.name === 'custom' ? item.customName : item.name;
+  return useModifiersStore().modifiers.filter((m) =>
+    m.enabled !== false &&
+    (m.option === 'Expertise' || m.option === 'Ability Reroll' || m.option === 'Ability') &&
+    m.modifiedOption === 'Bonus' &&
+    m.abilityFocus === focusName &&
+    m.modifiedValue === item.ability,
+  );
+}
 const props = defineProps({
   aim: { type: Boolean },
   aimValue: { type: Number },

--- a/ageofficial/src/components/qualities/QualitiesModal.vue
+++ b/ageofficial/src/components/qualities/QualitiesModal.vue
@@ -302,7 +302,7 @@
                 </div>
               </div>
             </div>
-              <div class="age-quality-modifiers"  v-if="(feature.type && feature.type !== 'Ability Focus' && feature.type !== 'Talent' && feature.type !== 'Specialization')">
+              <div class="age-quality-modifiers"  v-if="(feature.type && feature.type !== 'Ability Focus' && feature.type !== 'Specialization')">
                <h3 style="display: flex;">
                   <span>Modifiers</span>                  
                   <button class="link-btn" @click="addModifier" 
@@ -419,11 +419,12 @@ const setFocus = (selectedOption) => {
 const selected = ref(arcanaFocuses.value.includes(props.feature.name) ? `Arcana (${props.feature.name})` : psychicFocuses.value.includes(props.feature.name) ? `Psychic (${props.feature.name})` : props.feature.name || '');
 
 const modOptions = computed(() => {
-  if(useSettingsStore().showArcana){
-    return ['Ability Reroll', 'Armor Penalty', 'Armor Rating', 'Custom Attack', 'Damage', 'Defense','Speed','Spell'];
-  } else {
-    return ['Ability Reroll', 'Armor Penalty', 'Armor Rating', 'Custom Attack', 'Damage', 'Defense','Speed','Toughness'];
-  }
+  const base = useSettingsStore().showArcana
+    ? ['Expertise', 'Ability Reroll', 'Armor Penalty', 'Armor Rating', 'Custom Attack', 'Damage', 'Defense', 'Speed', 'Spell']
+    : ['Expertise', 'Ability Reroll', 'Armor Penalty', 'Armor Rating', 'Custom Attack', 'Damage', 'Defense', 'Speed', 'Toughness'];
+  // Expertise is a Talent-only modifier.
+  const filtered = props.feature?.type === 'Talent' ? base : base.filter((o) => o !== 'Expertise');
+  return filtered.sort((a, b) => a.localeCompare(b));
 })
 
 const qualityLevels = computed(() => {

--- a/ageofficial/src/sheet/stores/character/characterQualitiesStore.ts
+++ b/ageofficial/src/sheet/stores/character/characterQualitiesStore.ts
@@ -99,9 +99,10 @@ export const useItemStore = defineStore('quality', ()=>{
           })
         }
       }
-      if(mod.option === 'Ability Reroll'){
+      if(mod.option === 'Ability Reroll' || mod.option === 'Expertise'){
         Object.assign(newMod,{
-            abilityFocus: mod.abilityFocus
+            abilityFocus: mod.abilityFocus,
+            field: mod.field
           })
       }
       if(mod.option === 'Damage' || mod.option === 'Defense' || mod.option === 'Speed'){
@@ -121,7 +122,7 @@ export const useItemStore = defineStore('quality', ()=>{
           })
         }
       }   
-      if(mod.option === 'Ability Reroll'){
+      if(mod.option === 'Ability Reroll' || mod.option === 'Expertise'){
         Object.assign(newMod,{
             modifiedOption: mod.modifiedOption
           })

--- a/ageofficial/src/sheet/stores/modifiers/modifiersStore.ts
+++ b/ageofficial/src/sheet/stores/modifiers/modifiersStore.ts
@@ -24,6 +24,8 @@ export type Modifier = {
     label?:string;
     enabled?:boolean;
     abilityFocus?:string;
+    modifiedOption?:string;
+    field?:string;
 }
 export type ModifiersHydrate = {
     modifiers: {


### PR DESCRIPTION
Implements Expertise as a Talent modifier (Asana 1212244880377718): a focus-scoped +1 bonus (or reroll) that surfaces as its own row under the parent Ability Focus.

- ExpertiseModView: dedicated single-row editor (existing-focus dropdown, sub-focus label, Bonus/Reroll). Bonus auto-applies +1; the focus must already exist, so the user only picks from focuses they have.
- BaseModView routes the new 'Expertise' modifier option to it.
- QualitiesModal: enable the Modifiers section for Talents and expose the Expertise option for Talents only.
- ExpertiseRow: renders "Focus: Sub-Focus (Ability)" as a separate focus row with the rolled total, Expert reroll button, share-to-chat, and an edit gear that opens the parent Talent.
- characterQualitiesStore: persist Expertise modifier fields on create.
- modifiersStore: add field/modifiedOption to the Modifier type.