### PR TITLE
fix(css): restore button styles broken by inline style cleanup

### DIFF
--- a/ageofficial/src/components/enhancements/EnhancementsSection.vue
+++ b/ageofficial/src/components/enhancements/EnhancementsSection.vue
@@ -77,7 +77,7 @@ let enhancementNew = ref({
   padding: 15px 6px 6px;
   width: 100%;
 }
-.enh-add-btn {
+button.enh-add-btn {
   font-size: 1.5rem;
 }
 </style>

--- a/ageofficial/src/components/qualities/QualitiesTalentSection.vue
+++ b/ageofficial/src/components/qualities/QualitiesTalentSection.vue
@@ -169,7 +169,7 @@ function getQuality(quality) {
   display: flex;
   justify-content: flex-end;
 }
-.talent-add-btn {
+button.talent-add-btn {
   font-size: 1.5rem;
   margin-bottom: -32px;
 }

--- a/ageofficial/src/sheet/scss/index.scss
+++ b/ageofficial/src/sheet/scss/index.scss
@@ -833,6 +833,19 @@ body {
     border-radius: 2px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
     transition: all 0.3s ease;
+    & button {
+      margin: 0;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      cursor: pointer;
+      &.link-btn {
+        padding: 0.25rem;
+        font-weight: bold;
+        font-size: 14px;
+        transition: color 0.2s ease-in-out;
+      }
+    }
     & .age-modal-header,
     .age-modal-details-header {
       display: flex;


### PR DESCRIPTION
Modals are teleported to <body> and sit outside .examplesheet, so the .examplesheet button reset (background, border, padding) and link-btn styles never applied. Removing inline background/border overrides in the cleanup left icon buttons with browser-default gray styling.

Add an equivalent button reset inside body .age-modal so all teleported modals get correct transparent/borderless buttons and working link-btn styles site-wide.

Also fix specificity regression in EnhancementsSection and QualitiesTalentSection where .enh-add-btn/.talent-add-btn { font-size: 1.5rem } was losing to .examplesheet button.link-btn { font-size: 14px } (specificity 0,2,1 vs 0,2,0). Qualify both selectors with the button element to restore the intended icon size.
