### PR TITLE
Address CodeRabbit review on PR #112

### DIFF
--- a/ageofficial/src/App.vue
+++ b/ageofficial/src/App.vue
@@ -225,8 +225,16 @@
       class="age-import-overlay"
       @click.self="cancelImport"
     >
-      <div class="age-import-modal">
-        <h3>Import {{ importCharacterName }}</h3>
+      <div
+        ref="importModalRef"
+        class="age-import-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="age-import-title"
+        tabindex="-1"
+        @keydown="onImportKeydown"
+      >
+        <h3 id="age-import-title">Import {{ importCharacterName }}</h3>
         <p>
           Choose which sections to import, then add them to the sheet or
           overwrite the existing data.
@@ -285,7 +293,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 import { useAgeSheetStore } from "./sheet/stores";
 import PCView from "./views/PCView.vue";
@@ -367,9 +375,14 @@ const importCharacterName = computed(() =>
   initValues.character?.name ? `“${initValues.character.name}”` : "Character"
 );
 
+const importModalRef = ref(null);
+// The element focused before the modal opened, so focus can be restored on close.
+let importTrigger = null;
+
 const openImportModal = () => {
   // Start with every section selected.
   selectedSections.value = IMPORT_SECTIONS.map((s) => s.key);
+  importTrigger = document.activeElement;
   importModalOpen.value = true;
 };
 const confirmImport = (mode) => {
@@ -384,6 +397,47 @@ const confirmImport = (mode) => {
 const cancelImport = () => {
   importModalOpen.value = false;
 };
+
+// Selector for the focusable controls inside the modal (used for the focus trap).
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const onImportKeydown = (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    cancelImport();
+    return;
+  }
+  if (event.key !== "Tab") return;
+  const modal = importModalRef.value;
+  if (!modal) return;
+  const focusable = Array.from(
+    modal.querySelectorAll(FOCUSABLE_SELECTOR)
+  ).filter((el) => el.offsetParent !== null || el === modal);
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  // Wrap focus around the modal's edges so Tab never escapes to the page behind.
+  if (event.shiftKey && (active === first || active === modal)) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};
+
+// Move focus into the modal when it opens and restore it to the trigger on close.
+watch(importModalOpen, async (open) => {
+  if (open) {
+    await nextTick();
+    importModalRef.value?.focus();
+  } else if (importTrigger && typeof importTrigger.focus === "function") {
+    importTrigger.focus();
+    importTrigger = null;
+  }
+});
 </script>
 
 <style scoped lang="scss">

--- a/ageofficial/src/utility/legacyAdapter.ts
+++ b/ageofficial/src/utility/legacyAdapter.ts
@@ -35,6 +35,24 @@ type LegacyAttributes = Record<string, any>;
 type GroupedRepeating = Record<string, Array<Record<string, any>>>;
 
 /*
+ * All diagnostic console output in this module is gated behind `logMode` so it
+ * never runs in production (per the repo's dead-code policy). Flip to `true`
+ * during development to see the raw legacy blob and the import change report.
+ * Route every console call through these helpers rather than calling `console`
+ * directly.
+ */
+const logMode: boolean = false;
+const log = (...args: any[]) => {
+  if (logMode) console.log(...args);
+};
+const logWarn = (...args: any[]) => {
+  if (logMode) console.warn(...args);
+};
+const logInfo = (...args: any[]) => {
+  if (logMode) console.info(...args);
+};
+
+/*
  * Roll20 stores repeating rows as flat keys shaped
  *   repeating_<section>_<rowId>_<field>
  * where <section> and <field> may contain hyphens (e.g. `attack-list`,
@@ -70,7 +88,7 @@ export function groupRepeating(attributes: LegacyAttributes): GroupedRepeating {
 
 export function loadLegacyAbilityScores(attributes: LegacyAttributes) {
   if (!attributes) return;
-  console.log({
+  log({
     LegacyAbilities: {
       accuracy: attributes.accuracy,
       communication: attributes.communication,
@@ -99,12 +117,12 @@ export function loadLegacyCharacterDetails(attributes: LegacyAttributes) {
     armor: attributes.armor,
     weaponGroups: attributes["weapon-groups"],
   };
-  console.log({ LegacyRawAttributes: attributes, LegacyInfo: legacyInfo });
+  log({ LegacyRawAttributes: attributes, LegacyInfo: legacyInfo });
 }
 
 export function loadLegacyGroupings(attributes: LegacyAttributes) {
   if (!attributes) return;
-  console.log({ LegacyGroupings: groupRepeating(attributes) });
+  log({ LegacyGroupings: groupRepeating(attributes) });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -178,11 +196,17 @@ export function importLegacyCharacterFlat(attributes: LegacyAttributes) {
   // (the already-computed total) would double-count Dexterity. Default to the
   // AGE base of 10 when absent, so Speed isn't just the Dexterity value.
   const baseSpeed = toInt(attributes["base-speed"]);
-  char.speed = baseSpeed != null ? baseSpeed : 10;
+  if (baseSpeed != null) {
+    char.speed = baseSpeed;
+  } else if (!char.speed) {
+    // Only default to the AGE base of 10 when Speed is unset, so an append
+    // import doesn't clobber an existing value the user already has.
+    char.speed = 10;
+  }
 
   // XP lives on the structured character section and is optional (may be null).
   // It is not derived from level — the real value is used when present.
-  const xp = attributes.character?.character?.xp;
+  const xp = toInt(attributes.character?.character?.xp);
   if (xp != null) char.xp = xp;
 
   // Legacy stores weapon groups as a comma string (sometimes with a trailing
@@ -285,7 +309,10 @@ export const legacyCurrency = (money: Array<Record<string, any>>) => {
     if (letters.startsWith("g")) key = "gold";
     else if (letters.startsWith("s")) key = "silver";
     else if (letters.startsWith("c")) key = "copper";
-    if (key) inventory.cash[key] = amount;
+    // Accumulate: legacy sheets often have several rows of the same
+    // denomination, and append mode should add to existing cash, not replace it.
+    // Overwrite mode resets denominations first via clearSection("currency").
+    if (key) inventory.cash[key] = (inventory.cash[key] || 0) + amount;
   });
 };
 
@@ -382,8 +409,10 @@ export const legacyAttackWeapons = (attacks: Array<Record<string, any>>) => {
   const inventory = useInventoryStore();
   attacks.forEach((atk) => {
     if (!atk["attack-name"]) return;
-    const ranged = !!atk.range;
     const { shortRange, longRange } = parseRange(atk.range);
+    // Legacy rows use placeholder ranges like "0" or "-" for melee weapons;
+    // both are truthy strings, so classify from the parsed short range instead.
+    const ranged = shortRange != null && shortRange > 0;
     inventory.addItem({
       name: atk["attack-name"],
       description: "",
@@ -500,6 +529,7 @@ function diffStates(
 }
 
 function logImportReport(report: ImportReport) {
+  if (!logMode) return report;
   const { overwritten, added, cleared } = report;
   console.groupCollapsed(
     `📋 Legacy Import Report — ${overwritten.length} overwritten, ${added.length} added, ${cleared.length} cleared`
@@ -606,8 +636,10 @@ function clearSection(key: ImportSectionKey) {
       bio.profession = "";
       bio.background = "";
       bio.socialClass = "";
+      // Legacy `gender` is imported into bio.sex only (see importLegacyBioFlat),
+      // so bio.gender is left alone here — clearing it would delete a user value
+      // that the import never rewrites.
       bio.sex = "";
-      bio.gender = "";
       bio.height = "";
       bio.weight = "";
       bio.eyes = "";
@@ -621,7 +653,10 @@ function clearSection(key: ImportSectionKey) {
       break;
     }
     case "settings":
-      // Re-applying settings is sufficient; nothing to clear.
+      // gameSystem and incomeMode are always re-applied by importLegacySettingsFlat,
+      // but showArcana is only ever turned on there, so it must be reset here or a
+      // non-caster legacy character would leave the Arcana section visible.
+      useSettingsStore().showArcana = false;
       break;
     case "talents":
       removeQualitiesByType(["Talent", "Special Feature"]);
@@ -704,7 +739,7 @@ export function importLegacyCharacter(
   // Guard: never clear/overwrite the sheet when there's no legacy data to
   // import (e.g. the character blob hasn't loaded yet).
   if (!attributes || !isLegacyData(attributes)) {
-    console.warn(
+    logWarn(
       "⚠️ Legacy import skipped: no legacy character data found in the blob."
     );
     return;
@@ -714,13 +749,17 @@ export function importLegacyCharacter(
   ) as ImportSectionKey[];
 
   const sheet = useAgeSheetStore();
-  const before = sheet.dehydrateStore();
+  // The before/after snapshots and diff only feed the dev-only import report,
+  // so skip that work entirely unless logging is on.
+  const before = logMode ? sheet.dehydrateStore() : null;
   const grouped = groupRepeating(attributes);
 
   if (mode === "overwrite") selected.forEach((key) => clearSection(key));
   selected.forEach((key) => applySection(key, attributes, grouped, name));
 
-  const after = sheet.dehydrateStore();
-  logImportReport(diffStates(before, after));
-  console.info("✅ Legacy import complete");
+  if (logMode) {
+    const after = sheet.dehydrateStore();
+    logImportReport(diffStates(before, after));
+  }
+  logInfo("✅ Legacy import complete");
 }

--- a/ageofficial/src/views/SettingsView.vue
+++ b/ageofficial/src/views/SettingsView.vue
@@ -87,10 +87,16 @@
             </div>
             <div class="mb-3 col age-import-toggle-cell">
               <label class="age-checkbox-toggle age-checkbox-label">
-                <input type="checkbox" v-model="settings.allowImport" />
+                <input
+                  id="settings-allow-import"
+                  type="checkbox"
+                  v-model="settings.allowImport"
+                />
                 <span class="slider round"></span>
               </label>
-              <span class="age-toggle-label">Allow Import</span>
+              <label class="age-toggle-label" for="settings-allow-import"
+                >Allow Import</label
+              >
             </div>
           </div>
           <!-- // TODO Items unique to genre slices. Technofantasy, Cthulhu Awakens, Cyberpunk, etc. -->


### PR DESCRIPTION
Legacy import (src/utility/legacyAdapter.ts):
- Write char.speed only when base-speed is present; keep existing value on append instead of clobbering it with the default 10.
- Convert legacy xp through toInt so char.xp is always numeric.
- Accumulate money rows per denomination instead of overwriting, so repeated rows and append mode add up.
- Classify weapons Ranged/Melee from the parsed shortRange, not raw range truthiness (placeholder "0"/"-" no longer read as ranged).
- Gate all diagnostic console output behind a logMode flag via shared helpers, and skip the before/after dehydrate + diff work when logging is off.
- Don't clear bio.gender in overwrite mode; the import maps legacy gender to bio.sex only, so clearing gender would delete a user value nothing rewrites.
- Reset settings.showArcana to false in overwrite mode so a non-caster legacy character hides the Arcana section.

Import modal (src/App.vue):
- Add role="dialog", aria-modal, aria-labelledby, initial focus, a Tab focus trap, Escape-to-close, and focus restoration to the triggering element.

Settings (src/views/SettingsView.vue):
- Associate the "Allow Import" text with its checkbox via id/for.

## Submission Checklist
- [ ] The Pull Request title contains the **short name** of the sheet being submitted.
- [ ] The Pull Request title states the **type of change** being submitted (New/Update/Bugfix/etc.).
- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

## New Sheet Checklist
If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by `< >`.

- The full name of the game associated with the sheet is: `<   >`  
  - _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The name of this game system/family associated with the sheet is: `<   >` 
  - _(i.e. Dungeons & Dragons, FATE)_
- The publisher of the game associated with the sheet is: `<   >` 
  - _(i.e. Wizards of the Coast, Evil Hat)_

The information that is provided here will be used to help users find the sheet in Roll20 Tabletop and Roll20 Characters. Please make sure that all names that you provide read exactly how you'd like them to be displayed. To see example of where this information will show up, create a new game on Roll20. The Name and the publisher will show up in the dropdown menu and as the title of the sheet that is selected.

Please check any that apply:

# Changes / Description (optional)

Provide any notes relevant to this pull request here. This can include a description of the code changes, references to related pull requests, etc.

## More Help

Additional information for the beacon sdk can be found at the
[Beacon SDK Documentation Site](https://roll20.github.io/beacon-docs/docs/gettingstarted/introduction/).
You can also post additional questions using the
[Beacon Community GitHub Issues Tab](https://github.com/Roll20/roll20-beacon-sheets/issues).
